### PR TITLE
Add support for `-` and `*` bullet style in the metadata cell

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Exact Idea of MetaCell is:
 
 > **All and Only** Metadata should be stored at the first Cell of ipynb
 
-Writing a MetaCell is as simple as writting metadata in markdown file.
+Writing a MetaCell is as simple as writing metadata in markdown file.
 ```md
 # This is title
 + date: 2020-02-22
@@ -18,7 +18,10 @@ Writing a MetaCell is as simple as writting metadata in markdown file.
 ```
 > Hint: In jupyter notebook, press `Esc+M` will switch selected cell to markdown mode. 
 
-The `+` and space ` ` before any item will be automatically stripped out. If you don't like it, it's OK. But adding `+ ` will make metadata organized and enhance the readability of metacell:
+It is recommended (but not required) to organize the metadata items
+with Markdown bullets (`+`, `-` or `*`).
+These will be stripped during metadata extraction,
+but it keeps the metadata cell nicely readable in the notebook, like this:
 
 ### This is title
 + date: 2020-02-22

--- a/test/test_preprocess.py
+++ b/test/test_preprocess.py
@@ -1,0 +1,62 @@
+import textwrap
+
+from ..preprocess import Metadata
+
+import unittest
+
+
+class MetadataTest(unittest.TestCase):
+
+    def test_extract_cell_metadata_basic(self):
+        metadata = Metadata.extract_cell_metadata(textwrap.dedent("""\
+            # Animal Farm
+            + Author: George Orwell
+            + Date: 1945-08-17
+        """))
+        expected = {
+            'title': 'Animal Farm',
+            'author': 'George Orwell',
+            'date': '1945-08-17',
+        }
+        self.assertEqual(expected, metadata)
+
+    def test_extract_cell_metadata_other_bullets(self):
+        metadata = Metadata.extract_cell_metadata(textwrap.dedent("""\
+            # Animal Farm
+            - Author: George Orwell
+            * Date: 1945-08-17
+            Tags: books
+        """))
+        expected = {
+            'title': 'Animal Farm',
+            'author': 'George Orwell',
+            'date': '1945-08-17',
+            'tags': 'books',
+        }
+        self.assertEqual(expected, metadata)
+
+    def test_extract_cell_metadata_title_variation(self):
+        metadata = Metadata.extract_cell_metadata(textwrap.dedent("""\
+            + Author: George Orwell
+            ## Animal Farm
+            + Date: 1945-08-17
+        """))
+        expected = {
+            'title': 'Animal Farm',
+            'author': 'George Orwell',
+            'date': '1945-08-17',
+        }
+        self.assertEqual(expected, metadata)
+
+    def test_extract_cell_metadata_whitespace(self):
+        metadata = Metadata.extract_cell_metadata(textwrap.dedent("""\
+            #  Animal Farm
+               +  Author   :   George Orwell
+               +  Date     :   1945-08-17
+        """))
+        expected = {
+            'title': 'Animal Farm',
+            'author': 'George Orwell',
+            'date': '1945-08-17',
+        }
+        self.assertEqual(expected, metadata)


### PR DESCRIPTION
Made the metadata extraction less strict: add support for `-` and `*` bullet style,
title doesn't have to be first line, title can also be '##' or higher as well.
Simplified error handling during extraction, but made exception more helpful.

Also added some unittests for the metadata cell parsing