### PR TITLE
Bugfix: RemoveEmpty preprocessor should not remove non-empty cells that start with an empty line

### DIFF
--- a/preprocess.py
+++ b/preprocess.py
@@ -69,7 +69,7 @@ class RemoveEmpty(Preprocessor):
     @staticmethod
     def preprocess(nb, resources):
         nb.cells = [cell for cell in nb.cells
-                    if re.match(RemoveEmpty.visible, cell['source'])]
+                    if re.search(RemoveEmpty.visible, cell['source'])]
         if not nb.cells:
             raise Exception('No content cells after RemoveEmpty!')
         return nb, resources


### PR DESCRIPTION
I had a notebook with a markdown cell that started with an empty line, but had a lot of text.
In pelican the whole cell was gone.